### PR TITLE
Fix "slient" typos (and other nearby ones)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Terminal application for TI slient 700 with broken keys
+# Terminal application for TI silent 700 with broken keys
 
-We have a ti slient 700, and we wanted to connect it to something useful.
+We have a TI silent 700, and we wanted to connect it to something useful.
 
-Unfortunately it only sends in uppercase so using it as a modern day terminal alone is sort of out of the question. So this application allows us to run and develop applications for it which are vaugely useful.
+Unfortunately it only sends in uppercase so using it as a modern day terminal alone is sort of out of the question. So this application allows us to run and develop applications for it which are vaguely useful.
 
 ## Developing an application
 
-Make a new class somewhere in `apps/`. Inherit `TerminalApp` follow the docstring
+Make a new class somewhere in `apps/`. Inherit `TerminalApp`, follow the docstring.
 
-use `python mainterminal.py --dummy` to prototype
+Use `python mainterminal.py --dummy` to prototype.
 
 ### Reittiopas application
 

--- a/mainterminal.py
+++ b/mainterminal.py
@@ -32,7 +32,7 @@ class MainTerminal(TerminalApp):
                     pass
 
 
-            banner = "TI Slient 700 app"
+            banner = "TI Silent 700 app"
             leading_spaces = int((self.terminal_width - len(banner)) / 4)
             self.send((" "*leading_spaces) + banner)
             self.print_broken_keys()


### PR DESCRIPTION
Most annoyingly the one that keeps showing up in the app's banner.